### PR TITLE
Updating SS_MAX_MONTH_INCOME

### DIFF
--- a/src/stores.ts
+++ b/src/stores.ts
@@ -4,7 +4,7 @@ import { asCurrency } from "@/utils.js";
 
 const YEAR_BUSINESS_DAYS = 248;
 const MONTH_BUSINESS_DAYS = 22;
-const SS_MAX_MONTH_INCOME = 5318.4;
+const SS_MAX_MONTH_INCOME = 5765.16;
 
 interface TaxesState {
   income: number | null;


### PR DESCRIPTION
In 2023 the "IAS" was updated to 480,43€. Therefore the max SS value is 5765,16.

**Sources:**

- [Portal Finanças]( https://www.doutorfinancas.pt/simulador-seguranca-social-trabalhadores-independentes-2023/)

- [CGD](https://www.cgd.pt/Site/Saldo-Positivo/protecao/Pages/indexante-apoios-sociais.aspx#:~:text=Entre%202009%20e%202016%2C%20anos,%E2%82%AC%20para%20480%2C43%E2%82%AC.)