### PR TITLE
Change taxable income to always consider specific deductions

### DIFF
--- a/src/stores.ts
+++ b/src/stores.ts
@@ -147,15 +147,12 @@ const useTaxesStore = defineStore({
     },
     taxableIncome() {
       const grossIncome = this.grossIncome.year;
-      if (this.hasExpenses || this.expensesNeeded <= 0) {
-        const expensesMissing =
-          this.expensesNeeded > this.expenses
-            ? this.expensesNeeded - this.expenses
-            : 0;
+      const expensesMissing =
+        this.expensesNeeded > this.expenses
+          ? this.expensesNeeded - this.expenses
+          : 0;
 
-        return grossIncome * (this.firstYear ? 0.375 : this.secondYear ? 0.5625 :   0.75) + expensesMissing;
-      }
-      return grossIncome * (this.firstYear ? 0.45 : this.secondYear ? 0.675 :   0.9);
+      return grossIncome * (this.firstYear ? 0.375 : this.secondYear ? 0.5625 : 0.75) + expensesMissing;
     },
     taxRank(): TaxRank {
       return this.taxRanks.filter((taxRank: TaxRank, index: number) => {


### PR DESCRIPTION
Hi y'all,

I've created this PR because I think that the taxable income calculation was not accurate, for the cases were the user doesn't have expenses.
In that case, the taxable income was calculated with the 0,9 coefficient, and the specific deductions were ignored.

I recorded a small video to showcase the problem
https://github.com/franciscobmacedo/remotefreelancept/assets/24415119/3eb74eb7-ec83-4592-a27d-557a54f55fe4

Anything just reach out!

And thanks for the fantastic work @franciscobmacedo!! 
