### PR TITLE
feature: allow auto/manual setExpenses

### DIFF
--- a/cypress/e2e/test_simulator_to_url_parameters.cy.ts
+++ b/cypress/e2e/test_simulator_to_url_parameters.cy.ts
@@ -111,6 +111,18 @@ describe("pass expenses to url parameters", () => {
   });
 });
 
+describe("unset expenses from url parameters on expensesAuto", () => {
+    it("successfully reset expenses", () => {
+    cy.visit("/#/?income=50000");
+    cy.get('[data-cy="expenses"] input:first-of-type')
+      .invoke("val", "")
+      .type("3500");
+    cy.url().should("include", "expenses=3500");
+    cy.get('#setExpensesAutoButton').click();
+    cy.url().should("not.include", "expenses=");
+  });
+});
+
 describe("pass currentTaxRankYear to url parameters", () => {
   it("successfully uses currentTaxRankYear from simulator", () => {
     cy.visit("/#/?income=50000");

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -186,15 +186,13 @@
             class="flex flex-col items-center"
             link="https://www.cgd.pt/Site/Saldo-Positivo/leis-e-impostos/Pages/deducoes-especificas.aspx#:~:text=Empresariais%20e%20Profissionais%20(Categoria%20B)&text=Se%20estiver%20enquadrado%20no%20regime,bruto%20(antes%20dos%20descontos)."
           />
-          <Transition>
-            <button
-              class="text-xs text-neutral-500 flex flex-col items-center"
-              v-if="!store.expensesAuto"
-              @click="store.setExpensesAuto()"
-              id="setExpensesAutoButton"
-            >auto<ArrowPathIcon class="h-3" />
-            </button>
-          </Transition>
+          <button
+            class="text-xs text-neutral-500 flex flex-col items-center transition duration-500"
+            :class="store.expensesAuto ? 'invisible' : 'visible'"
+            @click="store.setExpensesAuto()"
+            id="setExpensesAutoButton"
+          >auto<ArrowPathIcon class="h-3" />
+          </button>
         </span>
       </div>
       <div class="flex justify-center mt-8">

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -181,13 +181,14 @@
           data-cy="expenses"
         >
         </AdjustCounter>
-        <span>
+        <span class="flex gap-2">
           <InfoButton
+            class="flex flex-col items-center"
             link="https://www.cgd.pt/Site/Saldo-Positivo/leis-e-impostos/Pages/deducoes-especificas.aspx#:~:text=Empresariais%20e%20Profissionais%20(Categoria%20B)&text=Se%20estiver%20enquadrado%20no%20regime,bruto%20(antes%20dos%20descontos)."
           />
           <Transition>
             <button
-              class="text-xs text-neutral-500"
+              class="text-xs text-neutral-500 flex flex-col items-center"
               v-if="!store.expensesAuto"
               @click="store.setExpensesAuto()"
               id="setExpensesAutoButton"

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -172,7 +172,7 @@
         </div>
         <AdjustCounter
           :value="store.expenses"
-          @update:value="store.setExpenses"
+          @update:value="store.setExpensesManual"
           :min="0"
           :max="grossIncome.year"
           :step="100"
@@ -181,9 +181,20 @@
           data-cy="expenses"
         >
         </AdjustCounter>
-        <InfoButton
-          link="https://www.cgd.pt/Site/Saldo-Positivo/leis-e-impostos/Pages/deducoes-especificas.aspx#:~:text=Empresariais%20e%20Profissionais%20(Categoria%20B)&text=Se%20estiver%20enquadrado%20no%20regime,bruto%20(antes%20dos%20descontos)."
-        />
+        <span>
+          <InfoButton
+            link="https://www.cgd.pt/Site/Saldo-Positivo/leis-e-impostos/Pages/deducoes-especificas.aspx#:~:text=Empresariais%20e%20Profissionais%20(Categoria%20B)&text=Se%20estiver%20enquadrado%20no%20regime,bruto%20(antes%20dos%20descontos)."
+          />
+          <Transition>
+            <button
+              class="text-xs text-neutral-500"
+              v-if="!store.expensesAuto"
+              @click="store.setExpensesAuto()"
+              id="setExpensesAutoButton"
+            >auto<ArrowPathIcon class="h-3" />
+            </button>
+          </Transition>
+        </span>
       </div>
       <div class="flex justify-center mt-8">
         <Chart />
@@ -237,6 +248,7 @@ import { storeToRefs } from "pinia";
 import { asCurrency } from "@/utils.js";
 import { FrequencyChoices } from "@/typings";
 import { SUPPORTED_TAX_RANK_YEARS, useTaxesStore } from "@/store";
+import { ArrowPathIcon } from "@heroicons/vue/24/outline";
 
 import Chart from "@/components/Chart.vue";
 import AdjustCounter from "@/components/AdjustCounter.vue";

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -325,7 +325,7 @@ const useTaxesStore = defineStore({
       this.expensesAuto = false;
       this.setExpenses(value);
     },
-    setExpensesAuto(v: any) {
+    setExpensesAuto() {
       this.expensesAuto = true;
       this.setExpenses(this.expensesNeeded);
       updateUrlQuery({

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -19,6 +19,7 @@ interface TaxesState {
   expensesTax: number;
   maxExpensesTax: number;
   expenses: number;
+  expensesAuto: boolean;
   ssDiscount: number;
   ssDiscountChoices: number[];
   currentTaxRankYear: (typeof SUPPORTED_TAX_RANK_YEARS)[number];
@@ -46,6 +47,7 @@ const useTaxesStore = defineStore({
     expensesTax: 15,
     maxExpensesTax: 15,
     expenses: 0,
+    expensesAuto: true,
     ssTax: 0.214,
     currentTaxRankYear: 2023,
     taxRanks: {
@@ -283,7 +285,9 @@ const useTaxesStore = defineStore({
         this.income = null;
       } else {
         this.income = value ? value : 0;
-        this.setExpenses(this.expensesNeeded);
+        if (this.expensesAuto) {
+          this.setExpenses(this.expensesNeeded);
+        }
       }
       updateUrlQuery({ income: this.income });
     },
@@ -316,6 +320,17 @@ const useTaxesStore = defineStore({
         this.expenses = value;
       }
       updateUrlQuery({ expenses: this.expenses });
+    },
+    setExpensesManual(value: number) {
+      this.expensesAuto = false;
+      this.setExpenses(value);
+    },
+    setExpensesAuto(v: any) {
+      this.expensesAuto = true;
+      this.setExpenses(this.expensesNeeded);
+      updateUrlQuery({
+        expenses: undefined,
+      });
     },
     setSsFirstYear(value: boolean) {
       this.ssFirstYear = value;
@@ -421,7 +436,7 @@ const useTaxesStore = defineStore({
       );
       this.setParameterFromUrl(
         params["expenses"],
-        this.setExpenses,
+        this.setExpensesManual,
         parseInt,
         numericValidator,
       );

--- a/src/style.scss
+++ b/src/style.scss
@@ -27,3 +27,12 @@ body {
 .v-leave-to {
   opacity: 0;
 }
+
+.visible {
+  opacity: 1;
+  visibility: visible;
+}
+.invisible {
+  opacity: 0;
+  visibility: visible;
+}

--- a/src/style.scss
+++ b/src/style.scss
@@ -18,3 +18,12 @@ html,
 body {
   background-color: #f5f5f5;
 }
+
+.v-enter-active,
+.v-leave-active {
+  transition: opacity 0.5s ease;
+}
+.v-enter-from,
+.v-leave-to {
+  opacity: 0;
+}


### PR DESCRIPTION

![image](https://github.com/franciscobmacedo/remotefreelancept/assets/5046551/f9759d6d-a98e-48cc-8cc5-212751a3e624)

features:
- when manually changing expenses value, new value is stored on UrlParams and changing Income does not modify this value
- when clicking "auto" button, expenses is removed from UrlParams and the value gets reset to the proper value
- when opening a new browser with expenses on UrlParams, this value gets used and expensesAuto=false (button is visible)
- the button appears/disappears with an smooth transition (ease)

ps: I don't love the layout, but I think it is good enough. I'm open to suggestions (but I have limited proficiency in html/css/vue)

closes #42 