### PR TITLE
feature: prevent numeric values to wrap in multiple lines

### DIFF
--- a/src/components/Chart.vue
+++ b/src/components/Chart.vue
@@ -4,7 +4,7 @@
     <div
       class="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2"
     >
-      <p class="text-center font-semibold text-lg text-neutral-600">
+      <p class="text-center font-semibold text-lg text-neutral-600 whitespace-nowrap">
         {{ asCurrency(grossIncome[displayFrequency]) }}
       </p>
       <small class="text-small">gross income</small>

--- a/src/components/CurrencyButton.vue
+++ b/src/components/CurrencyButton.vue
@@ -1,6 +1,6 @@
 <template>
   <button
-    class="bg-neutral-200 rounded-full px-3 py-2 hover:bg-neutral-300"
+    class="bg-neutral-200 rounded-full px-3 py-2 hover:bg-neutral-300 whitespace-nowrap"
     @click="store.setIncome(value)"
   >
     {{ asCurrency(value) }}

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -166,7 +166,7 @@
           </p>
           <span class="text-xs text-neutral-500"
             >the maximum required is
-            <span class="font-semibold">{{ asCurrency(expensesNeeded) }}</span>
+            <span class="font-semibold whitespace-nowrap">{{ asCurrency(expensesNeeded) }}</span>
             <span class="text-xs text-neutral-500">/year</span>
           </span>
         </div>

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -24,13 +24,13 @@
     <tbody>
       <tr>
         <td class="py-3">Gross income</td>
-        <td class="py-3">
+        <td class="py-3 whitespace-nowrap">
           {{ renderCellValue(grossIncome.year) }}
         </td>
-        <td class="py-3">
+        <td class="py-3 whitespace-nowrap">
           {{ renderCellValue(grossIncome.month) }}
         </td>
-        <td class="py-3">
+        <td class="py-3 whitespace-nowrap">
           {{ renderCellValue(grossIncome.day) }}
         </td>
       </tr>
@@ -52,7 +52,7 @@
       </tr>
       <tr class="border-b-2">
         <td class="pl-2 py-3">Specific deductions</td>
-        <td class="">
+        <td class="whitespace-nowrap">
           {{ renderCellValue(specificDeductions) }}
         </td>
         <td class="grey lighten-4"></td>
@@ -60,13 +60,13 @@
       </tr>
       <tr class="border-b-2">
         <td class="pl-2 py-3">Expenses</td>
-        <td class="">{{ renderCellValue(expenses) }}</td>
+        <td class="whitespace-nowrap">{{ renderCellValue(expenses) }}</td>
         <td class="grey lighten-4"></td>
         <td class="grey lighten-4"></td>
       </tr>
       <tr class="border-b-2">
         <td class="pl-2 py-3">Taxable income</td>
-        <td class="">
+        <td class="whitespace-nowrap">
           {{ renderCellValue(taxableIncome) }}
         </td>
         <td class="grey lighten-4"></td>
@@ -74,7 +74,7 @@
       </tr>
       <tr class="border-b-2">
         <td class="pl-2 py-3">Taxable income for average tax</td>
-        <td class="">
+        <td class="whitespace-nowrap">
           {{ renderCellValue(taxIncomeAvg) }}
         </td>
         <td class="grey lighten-4"></td>
@@ -82,7 +82,7 @@
       </tr>
       <tr class="">
         <td class="pl-2 py-3">Taxable income for normal tax</td>
-        <td class="">
+        <td class="whitespace-nowrap">
           {{ renderCellValue(taxIncomeNormal) }}
         </td>
         <td class="grey lighten-4"></td>
@@ -90,37 +90,37 @@
       </tr>
       <tr class="bg-red-100">
         <td class="pl-2 py-3">IRS</td>
-        <td class="">
+        <td class="whitespace-nowrap">
           {{ renderCellValue(irsPay.year) }}
         </td>
-        <td class="">
+        <td class="whitespace-nowrap">
           {{ renderCellValue(irsPay.month) }}
         </td>
-        <td class="">
+        <td class="whitespace-nowrap">
           {{ renderCellValue(irsPay.day) }}
         </td>
       </tr>
       <tr class="bg-blue-100">
         <td class="pl-2 py-3">Social security</td>
-        <td class="">
+        <td class="whitespace-nowrap">
           {{ renderCellValue(ssPay.year) }}
         </td>
-        <td class="">
+        <td class="whitespace-nowrap">
           {{ renderCellValue(ssPay.month) }}
         </td>
-        <td class="">
+        <td class="whitespace-nowrap">
           {{ renderCellValue(ssPay.day) }}
         </td>
       </tr>
       <tr class="bg-green-100">
         <td class="pl-2 py-3">Net income</td>
-        <td class="">
+        <td class="whitespace-nowrap">
           {{ renderCellValue(netIncome.year) }}
         </td>
-        <td class="">
+        <td class="whitespace-nowrap">
           {{ renderCellValue(netIncome.month) }}
         </td>
-        <td class="">
+        <td class="whitespace-nowrap">
           {{ renderCellValue(netIncome.day) }}
         </td>
       </tr>

--- a/src/components/TaxRanksDialog.vue
+++ b/src/components/TaxRanksDialog.vue
@@ -26,7 +26,7 @@
 
         <!-- Modal body -->
         <div class="p-6 space-y-6">
-          Your taxable income (<span class="text-income">{{
+          Your taxable income (<span class="text-income whitespace-nowrap">{{
             asCurrency(taxableIncome)
           }}</span
           >) is in level
@@ -56,12 +56,12 @@
                 >
                   {{ item.id }}
                 </td>
-                <td class="py-1 text-center">{{ asCurrency(item.min) }}</td>
-                <td class="py-1 text-center">{{ asCurrency(item.max) }}</td>
-                <td class="py-1 text-center">
+                <td class="py-1 text-center whitespace-nowrap">{{ asCurrency(item.min) }}</td>
+                <td class="py-1 text-center whitespace-nowrap">{{ asCurrency(item.max) }}</td>
+                <td class="py-1 text-center whitespace-nowrap">
                   {{ asPercentage(item.normalTax) }}
                 </td>
-                <td class="py-1 text-center">
+                <td class="py-1 text-center whitespace-nowrap">
                   {{ asPercentage(item.averageTax) }}
                 </td>
               </tr>


### PR DESCRIPTION
The fix:
![image](https://github.com/franciscobmacedo/remotefreelancept/assets/5046551/5e080d53-1ff6-4287-8bf5-8f18431043e0)

note: there is a really small space between columns, but that was already happening and this PR is not addressing that.

fixes: #49 