### PR TITLE
fix: Social Security calculation and discount

### DIFF
--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -23,6 +23,23 @@
         </div>
       </div>
       <div class="flex ml-3 md:ml-0 justify-start items-center mt-2 space-x-4">
+        <p class="text-sm w-fit">Income tax year</p>
+        <div class="w-16">
+          <DropDown
+            :choices="SUPPORTED_TAX_RANK_YEARS"
+            @change="changeCurrentTaxRankYear"
+            :value="getCurrentTaxRankYear.toString()"
+            data-cy="tax-rank-years-dropdown"
+          />
+        </div>
+        <InfoButton>
+          <p class="text-sm w-64 text-center">
+            There are a number of changes between 2023 and 2024, such as the
+            IAS value and the IRS brackets.
+          </p>
+        </InfoButton>
+      </div>
+      <div class="flex ml-3 md:ml-0 justify-start items-center mt-2 space-x-4">
         <p class="text-sm w-fit">Nr. of months to simulate your earnings</p>
         <AdjustCounter
           :value="store.nrMonthsDisplay"
@@ -58,22 +75,6 @@
             You can adjust your income for social security tax calculations with
             a minimum of -25% and a maximum of +25%. This will probably afect
             your retirement pension. Click to see more.
-          </p>
-        </InfoButton>
-      </div>
-      <div class="flex ml-3 md:ml-0 justify-start items-center mt-2 space-x-4">
-        <p class="text-sm w-fit">IRS tax rank year</p>
-        <div class="w-16">
-          <DropDown
-            :choices="SUPPORTED_TAX_RANK_YEARS"
-            @change="changeCurrentTaxRankYear"
-            :value="getCurrentTaxRankYear.toString()"
-            data-cy="tax-rank-years-dropdown"
-          />
-        </div>
-        <InfoButton>
-          <p class="text-sm w-64 text-center">
-            IRS tax rank year that is being simulated
           </p>
         </InfoButton>
       </div>

--- a/src/store/taxes.spec.ts
+++ b/src/store/taxes.spec.ts
@@ -141,8 +141,8 @@ describe("Taxes Store", () => {
     test.each([
       { income: 30_000, discount: 0.25 },
       { income: 30_000, discount: -0.25 },])
-    ("Low incomes cannot apply discounts because with the discount," +
-      "the monthly gross income is lower than the minimum SS pay", ({income, discount}) => {
+    ("Low incomes can apply discounts because with the discount," +
+      "the monthly gross income is still lower than the maximum SS pay", ({income, discount}) => {
       taxesStore.setIncome(income);
       taxesStore.setSsDiscount(discount);
 

--- a/src/store/taxes.spec.ts
+++ b/src/store/taxes.spec.ts
@@ -3,7 +3,6 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { createPinia } from "pinia";
 import {
   MONTH_BUSINESS_DAYS,
-  SS_MAX_MONTH_INCOME,
   SUPPORTED_TAX_RANK_YEARS,
   YEAR_BUSINESS_DAYS,
   useTaxesStore,
@@ -99,39 +98,79 @@ describe("Taxes Store", () => {
       taxesStore.setIncome(newGrossIncome);
 
       expect(taxesStore.ssPay.year).toBe(
-        SS_TAX * SS_MAX_MONTH_INCOME * MONTHS_IN_YEAR,
+        SS_TAX * taxesStore.maxSsIncome * MONTHS_IN_YEAR,
       );
-      expect(taxesStore.ssPay.month).toBe(SS_TAX * SS_MAX_MONTH_INCOME);
+      expect(taxesStore.ssPay.month).toBe(SS_TAX * taxesStore.maxSsIncome);
       expect(taxesStore.ssPay.day).toBe(
-        (SS_TAX * SS_MAX_MONTH_INCOME) / MONTH_BUSINESS_DAYS,
+        (SS_TAX * taxesStore.maxSsIncome) / MONTH_BUSINESS_DAYS,
       );
     });
 
-    it("when higher SS discount is applied", () => {
-      const newGrossIncome = 120_000;
+    it("when the income is lower than max ss pay, positive SS discount is applied", () => {
+      const newGrossIncome = 30_000;
       taxesStore.setIncome(newGrossIncome);
-      taxesStore.setSsDiscount(0.5);
+      taxesStore.setSsDiscount(0.25);
 
-      expect(taxesStore.ssPay.year).toBe(
-        SS_TAX * SS_MAX_MONTH_INCOME * 1.5 * MONTHS_IN_YEAR,
-      );
-      expect(taxesStore.ssPay.month).toBe(SS_TAX * SS_MAX_MONTH_INCOME * 1.5);
+      const monthlySsPay = Math.min(
+        taxesStore.maxSsIncome,
+        taxesStore.grossIncome.month * 0.7 * 1.25);
+
+      expect(taxesStore.ssPay.year).toBe(SS_TAX * monthlySsPay * MONTHS_IN_YEAR);
+      expect(taxesStore.ssPay.month).toBe(SS_TAX * monthlySsPay);
       expect(taxesStore.ssPay.day).toBe(
-        (SS_TAX * SS_MAX_MONTH_INCOME * 1.5) / MONTH_BUSINESS_DAYS,
+        (SS_TAX * monthlySsPay) / MONTH_BUSINESS_DAYS,
       );
     });
 
-    it("when lower SS discount is applied", () => {
-      const newGrossIncome = 120_000;
+    it("when income is lower, negative SS discount is applied", () => {
+      const newGrossIncome = 30_000;
       taxesStore.setIncome(newGrossIncome);
-      taxesStore.setSsDiscount(-0.5);
+      taxesStore.setSsDiscount(-0.25);
+
+      const monthlySsPay = Math.min(
+        taxesStore.maxSsIncome,
+        taxesStore.grossIncome.month * 0.7 * 0.75);
+
+      expect(taxesStore.ssPay.year).toBe(SS_TAX * monthlySsPay * MONTHS_IN_YEAR);
+      expect(taxesStore.ssPay.month).toBe(SS_TAX * monthlySsPay);
+      expect(taxesStore.ssPay.day).toBe(
+        (SS_TAX * monthlySsPay) / MONTH_BUSINESS_DAYS,
+      );
+    });
+
+    test.each([
+      { income: 30_000, discount: 0.25 },
+      { income: 30_000, discount: -0.25 },])
+    ("Low incomes cannot apply discounts because with the discount," +
+      "the monthly gross income is lower than the minimum SS pay", ({income, discount}) => {
+      taxesStore.setIncome(income);
+      taxesStore.setSsDiscount(discount);
+
+      const monthlySsPay = Math.min(
+        taxesStore.maxSsIncome,
+        taxesStore.grossIncome.month * 0.7 * (1 + discount));
+
+      expect(taxesStore.ssPay.year).toBe(SS_TAX * monthlySsPay * MONTHS_IN_YEAR);
+      expect(taxesStore.ssPay.month).toBe(SS_TAX * monthlySsPay);
+      expect(taxesStore.ssPay.day).toBe(
+        (SS_TAX * monthlySsPay) / MONTH_BUSINESS_DAYS
+      );
+    });
+
+    test.each([
+      { income: 200_000, discount: 0.25 },
+      { income: 200_000, discount: -0.25 },
+    ])("High incomes cannot apply discounts because even with the discount," +
+      "the monthly gross income is higher than the maximum SS pay", ({income, discount}) => {
+      taxesStore.setIncome(income);
+      taxesStore.setSsDiscount(discount);
 
       expect(taxesStore.ssPay.year).toBe(
-        SS_TAX * SS_MAX_MONTH_INCOME * 0.5 * MONTHS_IN_YEAR,
+        SS_TAX * taxesStore.maxSsIncome * MONTHS_IN_YEAR,
       );
-      expect(taxesStore.ssPay.month).toBe(SS_TAX * SS_MAX_MONTH_INCOME * 0.5);
+      expect(taxesStore.ssPay.month).toBe(SS_TAX * taxesStore.maxSsIncome);
       expect(taxesStore.ssPay.day).toBe(
-        (SS_TAX * SS_MAX_MONTH_INCOME * 0.5) / MONTH_BUSINESS_DAYS,
+        (SS_TAX * taxesStore.maxSsIncome) / MONTH_BUSINESS_DAYS,
       );
     });
   });


### PR DESCRIPTION
This PR introduces the following changes:
- Adds a per year IAS https://www.comparaja.pt/blog/indexante-dos-apoios-sociais
- Fix the BIC (Base incidência contributiva mensal) calculation -> 12*BIC #44 
- Fix discount calculation:
     - For high incomes, e.g., 15 000€/month, we cannot apply any discount up or down. Because it is still above the BIC, so for those incomes, the discount shouldn't have any effect.