### PR TITLE
Feature: save simulations

### DIFF
--- a/cypress/e2e/test_save_simulation_flow.cy.ts
+++ b/cypress/e2e/test_save_simulation_flow.cy.ts
@@ -1,0 +1,28 @@
+describe("simulator loads", () => {
+  it("successfully loads the home page", () => {
+    cy.visit("/#/");
+    cy.contains("h4", " Remote freelancer from Portugal 🇵🇹");
+  });
+});
+
+describe("pass income to url parameters", () => {
+  it("successfully save a new simulation", () => {
+    const simulationName = 'Rendimento líquido em 2023';
+
+    cy.visit("/#/");
+    cy.get('[data-cy="simulations-menu"]').should('not.exist');
+    cy.get('[data-cy="income"]').type("55000");
+    cy.get('[data-cy="save-simulation-button"]').click();
+    cy.get('[data-cy="simulation-name"]').type(simulationName);
+    cy.get('[data-cy="save-new-simulation-button"]').click();
+    cy.get('[data-cy="simulations-menu"]').should('exist');
+    cy.get('[data-cy="simulations-menu"]').click();
+    cy.contains("p", simulationName);
+    cy.get('[data-cy="open-simulation"]').click();
+    cy.url().should("include", "?income=55000");
+    cy.get('[data-cy="income"]').should('have.value', '55 000');
+    cy.get('[data-cy="simulations-menu"]').click();
+    cy.get('[data-cy="delete-simulation"]').click();
+    cy.get('[data-cy="simulations-menu"]').should('not.exist');
+  })
+});

--- a/src/components/Form.vue
+++ b/src/components/Form.vue
@@ -104,9 +104,8 @@
             <FrequencyButton />
           </div>
           </div>
-          <div class="inline-flex gap-5">
+          <div v-if="income !== null" class="inline-flex gap-5">
             <button
-            v-if="income !== null"
             class="text-sm hover:text-income hover:font-medium py-5 flex gap-2 items-center"
             @click="store.reset()"
           >
@@ -114,7 +113,6 @@
             <ArrowPathIcon class="h-3" />
           </button>
           <button
-            v-if="income !== null"
             class="text-sm hover:text-secondary hover:font-medium py-5 flex gap-2 items-center"
             @click="share"
           >
@@ -122,7 +120,7 @@
             <ShareIcon class="h-3" />
           </button>
           <button
-            v-if="income !== null"
+            data-cy="save-simulation-button"
             class="text-sm hover:text-tertiary hover:font-medium py-5 flex gap-2 items-center"
             @click="showNewSimulationDialog = true"
           >

--- a/src/components/Form.vue
+++ b/src/components/Form.vue
@@ -1,4 +1,18 @@
 <template>
+  <transition
+    enter-active-class="duration-300 ease-out"
+    enter-from-class="transform opacity-0"
+    enter-to-class="opacity-100"
+    leave-active-class="duration-200 ease-in"
+    leave-from-class="opacity-100"
+    leave-to-class="transform opacity-0"
+  >
+    <SaveSimulationDialog
+      v-if="showNewSimulationDialog"
+      @close="showNewSimulationDialog = false"
+      @saved="simulationSaved"
+    />
+  </transition>
   <div
     class="text-center transition delay-5 duration-100 ease-in-out flex"
     :class="{ 'h-screen': validationCount === 0 }"
@@ -6,10 +20,10 @@
     <div class="m-auto container max-w-2xl">
       <div class="relative md:h-44">
         <h4
-          class="font-semibold"
+          class="font-semibold mt-4 md:mt-0"
           :class="
             validationCount > 0
-              ? 'text-lg md:text-xl lg:text-2xl lg:w-[500px]'
+              ? 'text-lg md:text-xl lg:text-2xl'
               : 'text-lg sm:text-xl md:text-2-xl lg:text-3xl xl:text-4xl'
           "
         >
@@ -20,19 +34,19 @@
         >
           simulate your net income
         </p>
-        <div class="flex justify-around items-center">
-          <div
-            class="relative group"
-            :class="income === null ? 'w-7/12' : 'w-6/12'"
+        <div class="flex flex-col justify-around items-center md:flex-row">
+          <div class="flex items-center justify-center w-full">
+            <div
+            class="relative group w-7/12"
           >
             <div class="relative">
               <FormattedNumberInput
                 v-model:value="internalIncome"
                 placeholder="Income"
-                @click="showDropdown = true"
-                @update:value="showDropdown = false"
                 class="pl-7"
                 data-cy="income"
+                @click="showDropdown = true"
+                @update:value="showDropdown = false"
               />
 
               <ChevronDownIcon
@@ -68,10 +82,10 @@
               leave-to-class="transform opacity-0"
             >
               <div
-                v-click-outside="() => (showDropdown = false)"
-                @click="showDropdown = false"
                 v-if="showDropdown"
-                class="transition delay-5 duration-100 pt-5 pb-5 ease-in-out absolute w-full h-fit bg-neutral-100 rounded-md"
+                v-click-outside="() => (showDropdown = false)"
+                class="transition delay-5 duration-100 pt-5 pb-5 ease-in-out absolute w-full h-fit bg-neutral-100 rounded-md drop-shadow-md z-10"
+                @click="showDropdown = false"
               >
                 <div
                   class="flex flex-wrap gap-2 content-center justify-items-center place-items-center place-content-center text-center"
@@ -89,9 +103,11 @@
           <div :class="income === null ? 'w-4/12' : 'w-3/12'">
             <FrequencyButton />
           </div>
-          <button
+          </div>
+          <div class="inline-flex gap-5">
+            <button
             v-if="income !== null"
-            class="text-sm hover:text-income hover:font-medium pl-5 py-5 flex gap-2 items-center"
+            class="text-sm hover:text-income hover:font-medium py-5 flex gap-2 items-center"
             @click="store.reset()"
           >
             reset
@@ -99,20 +115,25 @@
           </button>
           <button
             v-if="income !== null"
-            class="text-sm hover:text-secondary hover:font-medium pl-5 py-5 flex gap-2 items-center"
+            class="text-sm hover:text-secondary hover:font-medium py-5 flex gap-2 items-center"
             @click="share"
           >
             share
             <ShareIcon class="h-3" />
           </button>
+          <button
+            v-if="income !== null"
+            class="text-sm hover:text-tertiary hover:font-medium py-5 flex gap-2 items-center"
+            @click="showNewSimulationDialog = true"
+          >
+            save
+            <BookmarkIcon class="h-3" />
+          </button>
+          </div>
         </div>
       </div>
     </div>
-    <ToastDialog
-      v-if="showToast"
-      text="sharable link copied to clipboard"
-      @close="closeToast"
-    />
+    <ToastDialog v-if="showToast" :text="toastMessage" @close="closeToast" />
   </div>
 </template>
 <script setup lang="ts">
@@ -122,6 +143,7 @@ import {
   ChevronDownIcon,
   ArrowPathIcon,
   ShareIcon,
+  BookmarkIcon,
 } from "@heroicons/vue/24/outline";
 import { storeToRefs } from "pinia";
 import { useTaxesStore } from "@/store";
@@ -130,6 +152,7 @@ import CurrencyButton from "@/components/CurrencyButton.vue";
 import ToastDialog from "@/components/ToastDialog.vue";
 import FormattedNumberInput from "@/components/FormattedNumberInput.vue";
 import FrequencyButton from "@/components/FrequencyButton.vue";
+import SaveSimulationDialog from "@/components/SaveSimulationDialog.vue";
 import { FrequencyChoices } from "@/typings";
 
 const { breakpoint } = useBreakpoint();
@@ -182,11 +205,22 @@ const changeAmount = computed(() => {
 
 // share
 const showToast = ref(false);
+const toastMessage = ref("");
+const showNewSimulationDialog = ref(false);
+
 const closeToast = () => {
   showToast.value = false;
 };
+
 const share = () => {
+  toastMessage.value = "sharable link copied to clipboard";
   navigator.clipboard.writeText(window.location.href);
+  showToast.value = true;
+};
+
+const simulationSaved = () => {
+  showNewSimulationDialog.value = false;
+  toastMessage.value = "Simulation saved";
   showToast.value = true;
 };
 </script>

--- a/src/components/PageHeader.vue
+++ b/src/components/PageHeader.vue
@@ -8,6 +8,7 @@
         </router-link>
         <router-link
           v-if="store.hasStoredSimulations"
+          data-cy="simulations-menu"
           class="flex items-center justify-center space-x-3"
           to="/simulations"
         >

--- a/src/components/PageHeader.vue
+++ b/src/components/PageHeader.vue
@@ -6,6 +6,13 @@
           <img src="@/assets/world.svg" class="h-7" />
           <span> simulator </span>
         </router-link>
+        <router-link
+          v-if="store.hasStoredSimulations"
+          class="flex items-center justify-center space-x-3"
+          to="/simulations"
+        >
+          <span> simulations ({{ store.storedSimulationsCount }}) </span>
+        </router-link>
         <router-link class="flex items-center justify-center" to="/about">
           about
         </router-link>
@@ -24,6 +31,10 @@
   </header>
 </template>
 <script lang="ts" setup>
+import { useTaxesStore } from "@/store";
 import { useBreakpoint } from "@/composables/breakpoints";
 const { breakpoint } = useBreakpoint();
+
+const store = useTaxesStore();
+store.loadSimulations();
 </script>

--- a/src/components/SaveSimulationDialog.vue
+++ b/src/components/SaveSimulationDialog.vue
@@ -35,6 +35,7 @@
                 v-model="simulationName"
                 type="text"
                 autocomplete="off"
+                data-cy="simulation-name"
                 class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg block w-full p-2.5"
                 placeholder="Simulation name"
                 required
@@ -43,6 +44,7 @@
             <div class="flex justify-end">
               <button
                 type="submit"
+                data-cy="save-new-simulation-button"
                 class="text-white bg-gray-700 hover:bg-gray-800 focus:ring-4 focus:outline-none focus:ring-gray-300 font-medium rounded-lg text-sm w-full sm:w-auto px-5 py-2.5 text-center"
               >
                 Save

--- a/src/components/SaveSimulationDialog.vue
+++ b/src/components/SaveSimulationDialog.vue
@@ -1,0 +1,73 @@
+<template>
+  <div
+    id="defaultModal"
+    tabindex="-1"
+    aria-hidden="true"
+    class="fixed top-0 left-0 right-0 z-50 w-full p-4 overflow-x-hidden overflow-y-auto md:inset-0 h-[calc(100%-1rem)] md:h-full bg-black bg-opacity-15"
+  >
+    <div
+      class="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-full h-full max-w-2xl md:h-auto"
+    >
+      <!-- Modal content -->
+      <div class="relative bg-neutral-200 rounded-lg shadow">
+        <!-- Modal header -->
+        <div class="flex items-start justify-between p-4 border-b rounded-t">
+          <h3 class="text-xl font-semibold text-gray-900">
+            Save this simulation
+          </h3>
+          <button
+            type="button"
+            class="text-gray-400 bg-transparent hover:text-gray-900 rounded-lg text-sm p-1.5 ml-auto inline-flex items-center"
+            data-modal-hide="defaultModal"
+            @click="$emit('close')"
+          >
+            <XMarkIcon class="w-5 h-5" />
+            <span class="sr-only">Close modal</span>
+          </button>
+        </div>
+
+        <!-- Modal body -->
+        <div class="p-6 space-y-6">
+          <form autocomplete="off" @submit.prevent="storeSimulation">
+            <div class="mb-6">
+              <input
+                id="simulation-name"
+                v-model="simulationName"
+                type="text"
+                autocomplete="off"
+                class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg block w-full p-2.5"
+                placeholder="Simulation name"
+                required
+              />
+            </div>
+            <div class="flex justify-end">
+              <button
+                type="submit"
+                class="text-white bg-gray-700 hover:bg-gray-800 focus:ring-4 focus:outline-none focus:ring-gray-300 font-medium rounded-lg text-sm w-full sm:w-auto px-5 py-2.5 text-center"
+              >
+                Save
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref } from "vue";
+import { useTaxesStore } from "@/store";
+import { XMarkIcon } from "@heroicons/vue/24/outline";
+
+// store
+const store = useTaxesStore();
+const simulationName = ref("");
+
+const emit = defineEmits(["close", "saved"]);
+
+const storeSimulation = () => {
+  store.storeSimulation(simulationName.value);
+  emit("saved");
+};
+</script>

--- a/src/components/TaxRanksDialog.vue
+++ b/src/components/TaxRanksDialog.vue
@@ -3,7 +3,7 @@
     id="defaultModal"
     tabindex="-1"
     aria-hidden="true"
-    class="fixed top-0 left-0 right-0 z-50 w-full p-4 overflow-x-hidden overflow-y-auto md:inset-0 h-[calc(100%-1rem)] md:h-full"
+    class="fixed top-0 left-0 right-0 z-50 w-full p-4 overflow-x-hidden overflow-y-auto md:inset-0 h-[calc(100%-1rem)] md:h-full bg-black bg-opacity-15"
   >
     <div
       class="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-full h-full max-w-2xl md:h-auto"

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,6 +1,7 @@
 import { createRouter, createWebHashHistory } from "vue-router";
 import Simulator from "@/views/SimulatorView.vue";
 import About from "@/views/AboutView.vue";
+import Simulations from "@/views/SimulationsView.vue";
 
 const routes = [
   {
@@ -12,6 +13,11 @@ const routes = [
     path: "/about",
     name: "About",
     component: About,
+  },
+  {
+    path: "/simulations",
+    name: "Simulations",
+    component: Simulations,
   },
 ];
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,11 +1,19 @@
 import { defineStore } from "pinia";
-import { FrequencyChoices, GrossIncome, TaxRank, Colors, YouthIrsRank, YouthIrs } from "@/typings";
-import { asCurrency } from "@/utils.js";
+import {
+  FrequencyChoices,
+  GrossIncome,
+  TaxRank,
+  Colors,
+  YouthIrsRank,
+  YouthIrs,
+} from "@/typings";
+import { asCurrency, generateUUID } from "@/utils.js";
 import { updateUrlQuery, clearUrlQuery } from "@/router";
 
 export const YEAR_BUSINESS_DAYS = 248;
 export const MONTH_BUSINESS_DAYS = 22;
 export const SUPPORTED_TAX_RANK_YEARS = [2023, 2024];
+const SIMULATIONS_LOCAL_STORE_KEY = "net_income_simulations";
 
 interface TaxesState {
   income: number | null;
@@ -33,6 +41,16 @@ interface TaxesState {
   ssFirstYear: boolean;
   benefitsOfYouthIrs: boolean;
   yearOfYouthIrs: 1 | 2 | 3 | 4 | 5;
+  storedSimulations:
+    | [
+        {
+          id: string;
+          simulationName: string;
+          createdAt: string;
+          parameters: Record<string, string>;
+        },
+      ]
+    | null;
 }
 const useTaxesStore = defineStore({
   id: "taxes",
@@ -105,10 +123,11 @@ const useTaxesStore = defineStore({
         3: { maxDiscountPercentage: 0.5, maxDiscountIasMultiplier: 20 },
         4: { maxDiscountPercentage: 0.5, maxDiscountIasMultiplier: 20 },
         5: { maxDiscountPercentage: 0.25, maxDiscountIasMultiplier: 10 },
-      }
+      },
     },
     benefitsOfYouthIrs: false,
     yearOfYouthIrs: 1,
+    storedSimulations: null,
   }),
   getters: {
     showDashboard: (state) => {
@@ -156,12 +175,14 @@ const useTaxesStore = defineStore({
       // then we compare it to the maximum SS income, and we take the minimum
       const monthSS =
         this.ssTax *
-        Math.min(this.maxSsIncome, this.grossIncome.month * 0.7 *
-          (1 + this.ssDiscount));
+        Math.min(
+          this.maxSsIncome,
+          this.grossIncome.month * 0.7 * (1 + this.ssDiscount),
+        );
       return {
         year: Math.max(12 * monthSS, 20 * 12),
         month: Math.max(monthSS, 20),
-        day: monthSS / MONTH_BUSINESS_DAYS
+        day: monthSS / MONTH_BUSINESS_DAYS,
       };
     },
     specificDeductions() {
@@ -195,7 +216,7 @@ const useTaxesStore = defineStore({
 
       return (
         (grossIncome - this.youthIrsDiscount) *
-        (this.firstYear ? 0.375 : this.secondYear ? 0.5625 : 0.75) +
+          (this.firstYear ? 0.375 : this.secondYear ? 0.5625 : 0.75) +
         expensesMissing
       );
     },
@@ -203,9 +224,12 @@ const useTaxesStore = defineStore({
       if (!this.benefitsOfYouthIrs) {
         return 0;
       }
-      const youthIrsRank = this.youthIrs[this.currentTaxRankYear][this.yearOfYouthIrs];
-      const maxDiscount = youthIrsRank.maxDiscountPercentage * this.grossIncome.year;
-      const maxDiscountIas = youthIrsRank.maxDiscountIasMultiplier * this.currentIas;
+      const youthIrsRank =
+        this.youthIrs[this.currentTaxRankYear][this.yearOfYouthIrs];
+      const maxDiscount =
+        youthIrsRank.maxDiscountPercentage * this.grossIncome.year;
+      const maxDiscountIas =
+        youthIrsRank.maxDiscountIasMultiplier * this.currentIas;
       return Math.min(maxDiscount, maxDiscountIas);
     },
     taxRank(): TaxRank {
@@ -262,7 +286,6 @@ const useTaxesStore = defineStore({
       }
       return this.taxableIncome - this.taxIncomeAvg;
     },
-
     irsPay() {
       if (this.taxRankAvg === undefined) {
         return {};
@@ -314,6 +337,12 @@ const useTaxesStore = defineStore({
     },
     netIncomeDisplay(): string {
       return asCurrency(this.netIncomeFrequency);
+    },
+    hasStoredSimulations() {
+      return this.storedSimulations && this.storedSimulations.length > 0;
+    },
+    storedSimulationsCount() {
+      return this.storedSimulations && this.storedSimulations.length;
     },
   },
   actions: {
@@ -382,7 +411,6 @@ const useTaxesStore = defineStore({
       updateUrlQuery({ yearOfYouthIrs: this.yearOfYouthIrs });
     },
     setFirstYear(value: boolean) {
-      console.log("firstYear store", value);
       this.firstYear = value;
       if (value === true && this.secondYear === true) {
         this.secondYear = false;
@@ -395,7 +423,6 @@ const useTaxesStore = defineStore({
       }
     },
     setSecondYear(value: boolean) {
-      console.log("secondYear store", value);
       this.secondYear = value;
       if (value === true) {
         this.firstYear = false;
@@ -411,7 +438,6 @@ const useTaxesStore = defineStore({
       this.rnh = value;
       updateUrlQuery({ rnh: this.rnh });
     },
-
     setParameterFromUrl(
       value: any,
       setter: CallableFunction,
@@ -510,8 +536,68 @@ const useTaxesStore = defineStore({
         null,
       );
       this.setParameterFromUrl(params["rnh"], this.setRnh, booleanParser, null);
-      this.setParameterFromUrl(params["benefitsOfYouthIrs"], this.setBenefitsOfYouthIrs, booleanParser, null);
-      this.setParameterFromUrl(params["yearOfYouthIrs"], this.setYearOfYouthIrs, parseInt, (value: number) => value >= 1 && value <= 5);
+      this.setParameterFromUrl(
+        params["benefitsOfYouthIrs"],
+        this.setBenefitsOfYouthIrs,
+        booleanParser,
+        null,
+      );
+      this.setParameterFromUrl(
+        params["yearOfYouthIrs"],
+        this.setYearOfYouthIrs,
+        parseInt,
+        (value: number) => value >= 1 && value <= 5,
+      );
+    },
+    getUrlParams() {
+      const urlParams = new URLSearchParams(
+        window.location.hash.split("/?")[1],
+      );
+
+      const params: { [key: string]: string | boolean } = {};
+
+      urlParams.forEach((value, key) => (params[key] = value));
+
+      return params;
+    },
+    setStoredSimulations(storedSimulations) {
+      this.storedSimulations = storedSimulations;
+    },
+    loadSimulations() {
+      if (!this.storedSimulations) {
+        const simulations = localStorage.getItem(SIMULATIONS_LOCAL_STORE_KEY);
+        this.storedSimulations = simulations ? JSON.parse(simulations) : [];
+      }
+    },
+    deleteSimulation(id: string) {
+      const index = this.storedSimulations.findIndex((s) => s.id === id);
+      if (index !== -1) {
+        this.storedSimulations.splice(index, 1);
+
+        this.updateStoredSimulations();
+      }
+    },
+    updateStoredSimulations() {
+      localStorage.setItem(
+        SIMULATIONS_LOCAL_STORE_KEY,
+        JSON.stringify(this.storedSimulations),
+      );
+    },
+    storeSimulation(simulationName: string) {
+      if (!this.storedSimulations) {
+        this.loadSimulations();
+      }
+
+      this.storedSimulations.push({
+        id: generateUUID(),
+        simulationName,
+        createdAt: new Date().toISOString(),
+        parameters: {
+          ...this.getUrlParams(),
+        },
+      });
+
+      this.updateStoredSimulations();
     },
     reset() {
       this.setIncome(null);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -23,3 +23,25 @@ export const reverseCurrency = (num: string) => {
   const result = parseFloat(num.replaceAll(" ", "").replaceAll("€", ""));
   return result <= 0 ? NaN : result;
 };
+
+export const formatISOString = (isoString: string): string => {
+  return new Date(isoString).toLocaleString("en");
+};
+
+export const generateUUID = (): string => {
+  const uuid: string[] = [];
+
+  for (let i = 0; i < 36; i++) {
+    if (i === 8 || i === 13 || i === 18 || i === 23) {
+      uuid[i] = "-";
+    } else if (i === 14) {
+      uuid[i] = "4";
+    } else if (i === 19) {
+      uuid[i] = (Math.floor(Math.random() * 4) + 8).toString(16);
+    } else {
+      uuid[i] = Math.floor(Math.random() * 16).toString(16);
+    }
+  }
+
+  return uuid.join("");
+};

--- a/src/views/SimulationsView.vue
+++ b/src/views/SimulationsView.vue
@@ -13,10 +13,10 @@ v-for="simulation in storedSimulationsSortedByDate" :key="simulation.id"
             <span class="font-light text-sm">{{ formatISOString(simulation.createdAt) }}</span>
           </div>
           <div class="flex items-center">
-            <router-link :to="{ name: 'Simulator', query: simulation.parameters }" class="inline-flex group p-2">
+            <router-link :to="{ name: 'Simulator', query: simulation.parameters }" class="inline-flex group p-2" data-cy="open-simulation">
               <ArrowRightEndOnRectangleIcon class="w-5 text-gray-500 group-hover:text-gray-900" />
             </router-link>
-            <button class="inline-flex p-2 group" @click="store.deleteSimulation(simulation.id)">
+            <button class="inline-flex p-2 group" @click="store.deleteSimulation(simulation.id)" data-cy="delete-simulation">
               <TrashIcon class="w-5 text-gray-500 group-hover:text-red-600" />
             </button>
           </div>

--- a/src/views/SimulationsView.vue
+++ b/src/views/SimulationsView.vue
@@ -1,0 +1,54 @@
+<template>
+  <div class="flex">
+    <div class="w-full pt-10 mx-2 md:mx-5 lg:mx-10 xl:mx-32 2xl:mx-60 3xl:mx-80">
+      <h4 class="font-semibold text-center lg:text-left text-lg md:text-xl lg:text-2xl lg:w-[500px] mb-8">
+        Saved simulations
+      </h4>
+      <ul v-if="store.storedSimulations" class="flex md:inline-flex flex-col gap-3">
+        <li
+v-for="simulation in storedSimulationsSortedByDate" :key="simulation.id"
+          class="inline-flex gap-4 w-full justify-between border-2 border-gray-300 px-3 py-2 rounded-md">
+          <div>
+            <p class="font-semibold">{{ simulation.simulationName }}</p>
+            <span class="font-light text-sm">{{ formatISOString(simulation.createdAt) }}</span>
+          </div>
+          <div class="flex items-center">
+            <router-link :to="{ name: 'Simulator', query: simulation.parameters }" class="inline-flex group p-2">
+              <ArrowRightEndOnRectangleIcon class="w-5 text-gray-500 group-hover:text-gray-900" />
+            </router-link>
+            <button class="inline-flex p-2 group" @click="store.deleteSimulation(simulation.id)">
+              <TrashIcon class="w-5 text-gray-500 group-hover:text-red-600" />
+            </button>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import {
+  ArrowRightEndOnRectangleIcon,
+  TrashIcon,
+} from "@heroicons/vue/24/outline";
+import { useTaxesStore } from "@/store";
+import { formatISOString } from "@/utils"
+import router from '@/router'
+
+const store = useTaxesStore();
+
+const storedSimulationsSortedByDate = computed(() => {
+  const simulations = [...store.storedSimulations];
+  return simulations.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+})
+
+store.$onAction(({ after, name }) => {
+  after(() => {
+    if (name === 'deleteSimulation' && !store.hasStoredSimulations) {
+      router.push('/')
+    }
+  })
+})
+
+</script>


### PR DESCRIPTION
It closes issue #33.

#### What was added

- New button to save the simulation
- New dialog to enter the simulation name
- New menu item that leads to the simulations page
- Simulations page where we list all saved simulations and the user can open or delete a simulation (If the user deletes the last one, he will be redirected to the Simulation page).
- The simulations menu only shows if there's any simulation saved

#### What was changed
- Minor changes on UI on mobile to fit the new 'save' button

> I'm most a React user these days, so it's possible that I missed some good practices from vue, if that's the case please let me know.

![image](https://github.com/user-attachments/assets/cdf0bbb8-ad66-46e2-b849-74c0c818973d)

Simulations page:

![image](https://github.com/user-attachments/assets/423247ef-8ba2-4de3-baf6-52fd7d8dcdd6)

