### PR TITLE
New feature: add number of days off / Fix: Inconsistency in the calculation of monthly and daily income

### DIFF
--- a/cypress/e2e/test_url_parameters_to_simulator.cy.ts
+++ b/cypress/e2e/test_url_parameters_to_simulator.cy.ts
@@ -105,10 +105,10 @@ describe("pass expenses through url parameters", () => {
 
 describe("pass currentTaxRankYear through url parameters", () => {
   it("successfully uses currentTaxRankYear from url", () => {
-    cy.visit("/#/?income=50000&currentTaxRankYear=2024"); // change URL to match your dev URL
+    cy.visit("/#/?income=50000&currentTaxRankYear=2023"); // change URL to match your dev URL
     cy.get('[data-cy="tax-rank-years-dropdown"] input:first-of-type').should(
       "have.value",
-      "2024",
+      "2023",
     );
   });
 
@@ -116,7 +116,7 @@ describe("pass currentTaxRankYear through url parameters", () => {
     cy.visit("/#/?income=50000&currentTaxRankYear=2025"); // change URL to match your dev URL
     cy.get('[data-cy="tax-rank-years-dropdown"] input:first-of-type').should(
       "have.value",
-      "2023",
+      "2024",
     );
   });
 
@@ -124,7 +124,7 @@ describe("pass currentTaxRankYear through url parameters", () => {
     cy.visit("/#/?income=50000&currentTaxRankYear=dummyval"); // change URL to match your dev URL
     cy.get('[data-cy="tax-rank-years-dropdown"] input:first-of-type').should(
       "have.value",
-      "2023",
+      "2024",
     );
   });
 });

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -24,7 +24,7 @@
       </div>
       <div class="flex ml-3 md:ml-0 justify-start items-center mt-2 space-x-4">
         <p class="text-sm w-fit">Income tax year</p>
-        <div class="w-20">
+        <div class="w-16">
           <DropDown
             :choices="SUPPORTED_TAX_RANK_YEARS"
             @change="changeCurrentTaxRankYear"

--- a/src/components/DropDown.vue
+++ b/src/components/DropDown.vue
@@ -15,7 +15,7 @@
     />
     <div
       v-if="showDropdown"
-      class="absolute top-5 shadow-lg bg-defaultbg w-full overflow-scroll h-max-64 z-10"
+      class="absolute top-5 shadow-lg bg-defaultbg overflow-scroll h-max-64 z-10 min-w-full w-20"
     >
       <button
         v-for="choice in choices"

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -49,7 +49,7 @@ const useTaxesStore = defineStore({
     expenses: 0,
     expensesAuto: true,
     ssTax: 0.214,
-    currentTaxRankYear: 2023,
+    currentTaxRankYear: 2024,
     taxRanks: {
       2023: [
         { id: 1, min: 0, max: 7479, normalTax: 0.145, averageTax: 0.145 },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import path from "path";
 
 export default defineConfig({
   plugins: [vue()],
+  base: "/remotefreelancept/",
   server: {
     port: process.env.PORT || null
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,7 @@ import path from "path";
 
 export default defineConfig({
   plugins: [vue()],
-  base: "/remotefreelancept/",
+  base: "/remotefreelancept/", //repo name
   server: {
     port: process.env.PORT || null
   },


### PR DESCRIPTION
### Set number of days-off in a year ( issue #54 ):

- Add new input field to set the number of unpaid days off in a year
- Update calculations for the simulation to consider the days off.

### Inconsistency on the calculation of monthly and daily income ( discussion #62 ):

- Change the logic for calculating income and deductions to take into account only the number of months and the number of working days in a year. It should no longer take into consideration the number of working days in a month.
- Remove reference to the number of working days in a month from the footer note.
- Removed constant variable to store the number of business days in a month.

### Cosmetics:

- Edit template element DropDown to increase the width of the option selection box for the field to select the Tax Year so that the options are readable without the need of horizontal scrolling.
- Reorder the options for Tax Year in descending order.
- When resetting the simulation, reset the Tax Year to the first option on the list (most recent year).
