### PR TITLE
fix: taxRank calculations

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -12,7 +12,7 @@ import { updateUrlQuery, clearUrlQuery } from "@/router";
 
 export const YEAR_BUSINESS_DAYS = 248;
 //export const MONTH_BUSINESS_DAYS = 22; // No longer used by this simulator, only year business days are taken into account
-export const SUPPORTED_TAX_RANK_YEARS = ([2023, 2024]).sort((a, b) => b - a);
+export const SUPPORTED_TAX_RANK_YEARS = [2023, 2024].sort((a, b) => b - a);
 const SIMULATIONS_LOCAL_STORE_KEY = "net_income_simulations";
 
 interface TaxesState {
@@ -92,7 +92,13 @@ const useTaxesStore = defineStore({
         { id: 4, min: 16472, max: 21321, normalTax: 0.25, averageTax: 0.18419 },
         { id: 5, min: 21321, max: 27146, normalTax: 0.32, averageTax: 0.21334 },
         { id: 6, min: 27146, max: 39791, normalTax: 0.35, averageTax: 0.25835 },
-        { id: 7, min: 39791, max: 43000, normalTax: 0.435, averageTax: 0.27154 },
+        {
+          id: 7,
+          min: 39791,
+          max: 43000,
+          normalTax: 0.435,
+          averageTax: 0.27154,
+        },
         { id: 8, min: 43000, max: 80000, normalTax: 0.45, averageTax: 0.35408 },
         { id: 9, min: 80000, normalTax: 0.48, max: null, averageTax: null },
       ],
@@ -239,7 +245,7 @@ const useTaxesStore = defineStore({
         (taxRank: TaxRank, index: number) => {
           const isLastRank =
             index === this.taxRanks[this.currentTaxRankYear].length - 1;
-          const isBiggerThanMin = taxRank.min < this.taxableIncome;
+          const isBiggerThanMin = taxRank.min <= this.taxableIncome;
           const isSmallerThanMax = taxRank.max >= this.taxableIncome;
 
           if (isLastRank && isBiggerThanMin) {
@@ -315,8 +321,10 @@ const useTaxesStore = defineStore({
       );
     },
     netIncome() {
-      const monthIncome = this.grossIncome.month - this.irsPay.month - this.ssPay.month;
-      const yearIncome = this.grossIncome.year - this.irsPay.year - this.ssPay.year;
+      const monthIncome =
+        this.grossIncome.month - this.irsPay.month - this.ssPay.month;
+      const yearIncome =
+        this.grossIncome.year - this.irsPay.year - this.ssPay.year;
       return {
         year: yearIncome,
         month: monthIncome,
@@ -620,7 +628,7 @@ const useTaxesStore = defineStore({
       this.setNrDaysOff(0);
       this.setSsDiscount(0);
       this.setExpenses(0);
-      this.setCurrentTaxRankYear( SUPPORTED_TAX_RANK_YEARS[0] );
+      this.setCurrentTaxRankYear(SUPPORTED_TAX_RANK_YEARS[0]);
       this.setSsFirstYear(false);
       this.setFirstYear(false);
       this.setSecondYear(false);

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -12,7 +12,7 @@ import { updateUrlQuery, clearUrlQuery } from "@/router";
 
 export const YEAR_BUSINESS_DAYS = 248;
 //export const MONTH_BUSINESS_DAYS = 22; // No longer used by this simulator, only year business days are taken into account
-export const SUPPORTED_TAX_RANK_YEARS = [2023, 2024].sort((a, b) => b - a);
+export const SUPPORTED_TAX_RANK_YEARS = ([2023, 2024]).sort((a, b) => b - a);
 const SIMULATIONS_LOCAL_STORE_KEY = "net_income_simulations";
 
 interface TaxesState {
@@ -92,13 +92,7 @@ const useTaxesStore = defineStore({
         { id: 4, min: 16472, max: 21321, normalTax: 0.25, averageTax: 0.18419 },
         { id: 5, min: 21321, max: 27146, normalTax: 0.32, averageTax: 0.21334 },
         { id: 6, min: 27146, max: 39791, normalTax: 0.35, averageTax: 0.25835 },
-        {
-          id: 7,
-          min: 39791,
-          max: 43000,
-          normalTax: 0.435,
-          averageTax: 0.27154,
-        },
+        { id: 7, min: 39791, max: 43000, normalTax: 0.435, averageTax: 0.27154 },
         { id: 8, min: 43000, max: 80000, normalTax: 0.45, averageTax: 0.35408 },
         { id: 9, min: 80000, normalTax: 0.48, max: null, averageTax: null },
       ],
@@ -321,10 +315,8 @@ const useTaxesStore = defineStore({
       );
     },
     netIncome() {
-      const monthIncome =
-        this.grossIncome.month - this.irsPay.month - this.ssPay.month;
-      const yearIncome =
-        this.grossIncome.year - this.irsPay.year - this.ssPay.year;
+      const monthIncome = this.grossIncome.month - this.irsPay.month - this.ssPay.month;
+      const yearIncome = this.grossIncome.year - this.irsPay.year - this.ssPay.year;
       return {
         year: yearIncome,
         month: monthIncome,
@@ -628,7 +620,7 @@ const useTaxesStore = defineStore({
       this.setNrDaysOff(0);
       this.setSsDiscount(0);
       this.setExpenses(0);
-      this.setCurrentTaxRankYear(SUPPORTED_TAX_RANK_YEARS[0]);
+      this.setCurrentTaxRankYear( SUPPORTED_TAX_RANK_YEARS[0] );
       this.setSsFirstYear(false);
       this.setFirstYear(false);
       this.setSecondYear(false);

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -4,7 +4,6 @@ import {
   GrossIncome,
   TaxRank,
   Colors,
-  YouthIrsRank,
   YouthIrs,
 } from "@/typings";
 import { asCurrency, generateUUID } from "@/utils.js";
@@ -33,6 +32,9 @@ interface TaxesState {
   currentTaxRankYear: (typeof SUPPORTED_TAX_RANK_YEARS)[number];
   taxRanks: { [K in (typeof SUPPORTED_TAX_RANK_YEARS)[number]]: TaxRank[] };
   iasPerYear: { [K in (typeof SUPPORTED_TAX_RANK_YEARS)[number]]: number };
+  minimumExistencePerYear: {
+    [K in (typeof SUPPORTED_TAX_RANK_YEARS)[number]]: number;
+  };
   youthIrs: { [K in (typeof SUPPORTED_TAX_RANK_YEARS)[number]]: YouthIrs };
   colors: Colors;
   rnh: boolean;
@@ -100,6 +102,10 @@ const useTaxesStore = defineStore({
     iasPerYear: {
       2023: 480.43,
       2024: 509.26,
+    },
+    minimumExistencePerYear: {
+      2023: 10_640,
+      2024: 11_480,
     },
     rnh: false,
     rnhTax: 0.2,
@@ -215,6 +221,9 @@ const useTaxesStore = defineStore({
         this.expensesNeeded > this.expenses
           ? this.expensesNeeded - this.expenses
           : 0;
+
+      if (grossIncome <= this.minimumExistence) return 0;
+      //TODO: calculate L to have some % not taxable  -> (grossIncome > this.minimumExistence) && (grossIncome <= L)
 
       return (
         (grossIncome - this.youthIrsDiscount) *
@@ -346,6 +355,12 @@ const useTaxesStore = defineStore({
     },
     storedSimulationsCount() {
       return this.storedSimulations && this.storedSimulations.length;
+    },
+    minimumExistence() {
+      return Math.max(
+        1.5 * 14 * this.iasPerYear[this.currentTaxRankYear],
+        this.minimumExistencePerYear[this.currentTaxRankYear],
+      );
     },
   },
   actions: {


### PR DESCRIPTION
The error is due to taxRank being undefined.
Since that in the first year of youth IRS in 2024 the discount percentage is 100%, if the gross income was low it didn't have enough taxes so the taxable income would be 0. which was not accounted for in the in the taxRank calculations

This resolves #60 