### PR TITLE
Issue #64: Expenses are not loaded from the URL

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -478,7 +478,13 @@ const useTaxesStore = defineStore({
           value as (typeof SUPPORTED_TAX_RANK_YEARS)[number],
         );
 
-      const incomeResult = this.setParameterFromUrl(
+        this.setParameterFromUrl(
+          params["incomeFrequency"],
+          this.setIncomeFrequency,
+          null,
+          frequencyChoicesValidator,
+        );
+        const incomeResult = this.setParameterFromUrl(
         params["income"],
         this.setIncome,
         parseInt,
@@ -487,13 +493,6 @@ const useTaxesStore = defineStore({
       if (incomeResult) {
         this.validationCount++;
       }
-
-      this.setParameterFromUrl(
-        params["incomeFrequency"],
-        this.setIncomeFrequency,
-        null,
-        frequencyChoicesValidator,
-      );
       this.setParameterFromUrl(
         params["displayFrequency"],
         this.setDisplayFrequency,


### PR DESCRIPTION
Adresses issue #64 

**Solution:** 
- The income frequency should be set before setting the income when configuring parameters from the URL.

**Root cause:** 
- When setting parameters from the URL, the value of expenses gets set after updating the income value. At this point, the `incomeFrequency` parameter has not yet been retrieved from the URL and retains its default value of `'year'`, resulting in an `expensesNeeded` value of `0`, and consequently, expenses of `0`.

