### PR TITLE
Fix youth irs

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -266,7 +266,7 @@ const useTaxesStore = defineStore({
         (taxRank: TaxRank, index: number) => {
           const isLastRank =
             index === this.taxRanks[this.currentTaxRankYear].length - 1;
-          const isBiggerThanMin = taxRank.min < this.taxableIncome;
+          const isBiggerThanMin = taxRank.min <= this.taxableIncome;
           const isSmallerThanMax = taxRank.max >= this.taxableIncome;
 
           if (isLastRank && isBiggerThanMin) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,7 +7,7 @@ export const formatNumber = (num: string) => {
 };
 
 export const spacedNumber = (num: number, decimalPlaces = 0) => {
-  if (num === null) return "";
+  if (num === null || num === undefined) return "";
   return formatNumber(num.toFixed(decimalPlaces));
 };
 


### PR DESCRIPTION
When we are selecting "Are you eligible for Youth IRS?" we are getting an error and the page breaks.

This fixes the problem by checking for `undefined` nums in the `spacedNumber` function and doing the same as for `null`s. 

Also, when calculating the taxRank with 0 of IRS, we were getting `NaN` in the "Net income" and "Tax Rank".