### PR TITLE
Add 2026 tax year support

### DIFF
--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -34,7 +34,7 @@
         </div>
         <InfoButton>
           <p class="text-sm w-64 text-center">
-            There are a number of changes between 2023 and 2024, such as the
+            There are a number of changes between years, such as the
             IAS value and the IRS brackets.
           </p>
         </InfoButton>

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -12,7 +12,8 @@ import { updateUrlQuery, clearUrlQuery } from "@/router";
 
 export const YEAR_BUSINESS_DAYS = 248;
 //export const MONTH_BUSINESS_DAYS = 22; // No longer used by this simulator, only year business days are taken into account
-export const SUPPORTED_TAX_RANK_YEARS = ([2023, 2024, 2025]).sort((a, b) => b - a);
+export const SUPPORTED_TAX_RANK_YEARS = ([2023, 2024, 2025, 2026]).sort((a, b) => b - a);
+export const DEFAULT_TAX_RANK_YEAR: (typeof SUPPORTED_TAX_RANK_YEARS)[number] = 2025;
 const SIMULATIONS_LOCAL_STORE_KEY = "net_income_simulations";
 
 interface TaxesState {
@@ -72,7 +73,7 @@ const useTaxesStore = defineStore({
     expenses: 0,
     expensesAuto: true,
     ssTax: 0.214,
-    currentTaxRankYear: SUPPORTED_TAX_RANK_YEARS[0], //This array should be sorted in descending order
+    currentTaxRankYear: DEFAULT_TAX_RANK_YEAR,
     taxRanks: {
       2023: [
         { id: 1, min: 0, max: 7479, normalTax: 0.145, averageTax: 0.145 },
@@ -107,11 +108,23 @@ const useTaxesStore = defineStore({
         { id: 8, min: 44987, max: 83696, normalTax: 0.45, averageTax: 0.35408 },
         { id: 9, min: 83696, normalTax: 0.48, max: null, averageTax: null },
       ],
+      2026: [
+        { id: 1, min: 0, max: 8342, normalTax: 0.125, averageTax: 0.125 },
+        { id: 2, min: 8342, max: 12587, normalTax: 0.157, averageTax: 0.13579 },
+        { id: 3, min: 12587, max: 17838, normalTax: 0.212, averageTax: 0.15823 },
+        { id: 4, min: 17838, max: 23089, normalTax: 0.241, averageTax: 0.17705 },
+        { id: 5, min: 23089, max: 29397, normalTax: 0.311, averageTax: 0.20579 },
+        { id: 6, min: 29397, max: 43090, normalTax: 0.349, averageTax: 0.2513 },
+        { id: 7, min: 43090, max: 46566, normalTax: 0.431, averageTax: 0.26472 },
+        { id: 8, min: 46566, max: 86634, normalTax: 0.446, averageTax: 0.34856 },
+        { id: 9, min: 86634, normalTax: 0.48, max: null, averageTax: null },
+      ],
     },
     iasPerYear: {
       2023: 480.43,
       2024: 509.26,
       2025: 522.50,
+      2026: 537.13,
     },
     rnh: false,
     rnhTax: 0.2,
@@ -139,6 +152,18 @@ const useTaxesStore = defineStore({
         5: { maxDiscountPercentage: 0.25, maxDiscountIasMultiplier: 10 },
       },
       2025: {
+        1: { maxDiscountPercentage: 1, maxDiscountIasMultiplier: 55 },
+        2: { maxDiscountPercentage: 0.75, maxDiscountIasMultiplier: 55 },
+        3: { maxDiscountPercentage: 0.75, maxDiscountIasMultiplier: 55 },
+        4: { maxDiscountPercentage: 0.75, maxDiscountIasMultiplier: 55 },
+        5: { maxDiscountPercentage: 0.50, maxDiscountIasMultiplier: 55 },
+        6: { maxDiscountPercentage: 0.50, maxDiscountIasMultiplier: 55 },
+        7: { maxDiscountPercentage: 0.50, maxDiscountIasMultiplier: 55 },
+        8: { maxDiscountPercentage: 0.25, maxDiscountIasMultiplier: 55 },
+        9: { maxDiscountPercentage: 0.25, maxDiscountIasMultiplier: 55 },
+        10: { maxDiscountPercentage: 0.25, maxDiscountIasMultiplier: 55 },
+      },
+      2026: {
         1: { maxDiscountPercentage: 1, maxDiscountIasMultiplier: 55 },
         2: { maxDiscountPercentage: 0.75, maxDiscountIasMultiplier: 55 },
         3: { maxDiscountPercentage: 0.75, maxDiscountIasMultiplier: 55 },
@@ -259,7 +284,7 @@ const useTaxesStore = defineStore({
       return Math.min(maxDiscount, maxDiscountIas);
     },
     youthIrsRange() {
-      return this.currentTaxRankYear === 2025 ? 10 : 5;
+      return Object.keys(this.youthIrs[this.currentTaxRankYear]).length;
     },
     taxRank(): TaxRank {
       return this.taxRanks[this.currentTaxRankYear].filter(
@@ -641,8 +666,7 @@ const useTaxesStore = defineStore({
       this.updateStoredSimulations();
     },
     isYearOfYouthIrsValid (value: number)  {
-      const validRange = this.currentTaxRankYear === 2025 ? 10 : 5;
-      return value >= 1 && value <= validRange;
+      return value >= 1 && value <= this.youthIrsRange;
     },
     reset() {
       this.setIncome(null);
@@ -652,7 +676,7 @@ const useTaxesStore = defineStore({
       this.setNrDaysOff(0);
       this.setSsDiscount(0);
       this.setExpenses(0);
-      this.setCurrentTaxRankYear( SUPPORTED_TAX_RANK_YEARS[0] );
+      this.setCurrentTaxRankYear( DEFAULT_TAX_RANK_YEAR );
       this.setSsFirstYear(false);
       this.setFirstYear(false);
       this.setSecondYear(false);

--- a/src/store/taxes.spec.ts
+++ b/src/store/taxes.spec.ts
@@ -370,5 +370,17 @@ describe("Taxes Store", () => {
     expect(taxesStore.getTaxRanks[6].max).toEqual(50483);
     expect(taxesStore.getTaxRanks[7].max).toEqual(78834);
     expect(taxesStore.getTaxRanks[8].max).toBeFalsy();
+
+    taxesStore.setCurrentTaxRankYear(2026);
+
+    expect(taxesStore.getTaxRanks[0].max).toEqual(8342);
+    expect(taxesStore.getTaxRanks[1].max).toEqual(12587);
+    expect(taxesStore.getTaxRanks[2].max).toEqual(17838);
+    expect(taxesStore.getTaxRanks[3].max).toEqual(23089);
+    expect(taxesStore.getTaxRanks[4].max).toEqual(29397);
+    expect(taxesStore.getTaxRanks[5].max).toEqual(43090);
+    expect(taxesStore.getTaxRanks[6].max).toEqual(46566);
+    expect(taxesStore.getTaxRanks[7].max).toEqual(86634);
+    expect(taxesStore.getTaxRanks[8].max).toBeFalsy();
   });
 });


### PR DESCRIPTION
- Add 2026 IRS brackets (Art. 68 CIRS), IAS (537.13), and Youth IRS data
- Introduce DEFAULT_TAX_RANK_YEAR constant to keep 2025 as the default (IRS declarations filed in 2026 use 2025 tax year)
- Derive youthIrsRange from data instead of hardcoding year checks
- Make info tooltip text year-agnostic